### PR TITLE
fix: support guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.12",


### PR DESCRIPTION
Guzzle 7 is out and required by default in the latest versions of some frameworks.

None of the breaking changes seem to affect this library:
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md
