### PR TITLE
Bump guzzle to ^7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "hubspot/api-client",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Hubspot API client",
     "keywords": [
         "hubspot",
@@ -22,7 +22,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.12",


### PR DESCRIPTION
Currently you cannot use this client in frameworks like laravel 8, as they require guzzle ^7.2.

This change should not break any tests.