### PR TITLE
Remove extra $ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $contact = $hubSpot->crm()->contacts()->basicApi()->create($contactInput);
 
 ```php
 $newProperties = new \HubSpot\Client\Crm\Contacts\Model\SimplePublicObjectInput();
-$newProperties->setProperties($[
+$newProperties->setProperties([
     'email' => 'updatedExample@example.com'
 ]);
 


### PR DESCRIPTION
Hi,

I noticed you've got a left over `$` from where you removed `$_POST` from the examples a couple of weeks ago. I've removed it in this PR.

Thanks for making and maintaining this repo