### PR TITLE
Update phpdoc

### DIFF
--- a/codegen/Crm/Deals/Api/AssociationsApi.php
+++ b/codegen/Crm/Deals/Api/AssociationsApi.php
@@ -401,9 +401,9 @@ class AssociationsApi
      *
      * Create
      *
-     * @param  int $deal_id deal_id (required)
+     * @param  string $deal_id deal_id (required)
      * @param  string $to_object_type to_object_type (required)
-     * @param  int $to_object_id to_object_id (required)
+     * @param  string $to_object_id to_object_id (required)
      * @param  \HubSpot\Client\Crm\Deals\Model\AssociationSpec[] $association_spec association_spec (required)
      *
      * @throws \HubSpot\Client\Crm\Deals\ApiException on non-2xx response


### PR DESCRIPTION
When I request the API, the ids are sent as strings. 
So when I call this endpoint, it's with strings too. 
Or maybe in some cases it might be integer, in this case change it to `int|string` ? (your API documentation also indicates that ids are strings)

(of course there are many more places where this needs to be changes)