### PR TITLE
Adding support to use developer api keys in direct api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ $response = $hubspot->apiRequest([
     'path' => string, // URL path (e.g.: '/crm/v3/objects/contacts'). Optional
     'headers' => array, // Http headers. Optional.
     'body' => mixed, // Request body (if defaultJson set body will be transforted to json string).Optional.
-    'authType' => enum(none, accessToken, hapikey), // Auth type. if it isn't set it will use accessToken or hapikey. Default value is non empty auth type.
+    'authType' => enum(none, accessToken, hapikey, developerApiKey), // Auth type. if it isn't set it will use accessToken or hapikey. Default value is non empty auth type.
     'baseUrl' => string, // Base URL. Default value 'https://api.hubapi.com'.
     'qs' => array, // Query parameters. Optional.
     'defaultJson' => bool, // Default Json. if it is set to true it add to headers [ 'Content-Type' => 'application/json', 'Accept' => 'application/json, */*;q=0.8',]

--- a/lib/Http/Auth.php
+++ b/lib/Http/Auth.php
@@ -39,6 +39,7 @@ class Auth
     {
         return [
             'accessToken' => 'getAccessToken',
+            'developerApiKey' => 'getDeveloperApiKey',
             'hapikey' => 'getApiKey',
         ];
     }

--- a/lib/Http/Request.php
+++ b/lib/Http/Request.php
@@ -67,6 +67,9 @@ class Request
             if ('hapikey' === $auth['type']) {
                 $this->options['qs']['hapikey'] = $auth['value'];
             }
+            if ('developerApiKey' === $auth['type']) {
+                $this->options['qs']['hapikey'] = $auth['value'];
+            }
 
             if ('accessToken' === $auth['type']) {
                 $this->headers['Authorization'] = "Bearer {$auth['value']}";
@@ -110,7 +113,7 @@ class Request
         $urlStr .= $this->options['path'] ?? '';
 
         if (array_key_exists('qs', $this->options) && !empty($this->options['qs'])) {
-            $urlStr .= '?'.http_build_query($this->options['qs'], '', '&', PHP_QUERY_RFC3986);
+            $urlStr .= '?' . http_build_query($this->options['qs'], '', '&', PHP_QUERY_RFC3986);
         }
 
         return $urlStr;


### PR DESCRIPTION
I ran into https://github.com/HubSpot/hubspot-api-php/issues/236 and decided to go direct with $client->apiRequest() but apiRequest() didn't directly support developer api keys.

