### PR TITLE
Fix namespace on Enums\AssocationTypes

### DIFF
--- a/lib/Enums/AssociationTypes.php
+++ b/lib/Enums/AssociationTypes.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Enums;
+namespace HubSpot\Enums;
 
 class AssociationTypes
 {


### PR DESCRIPTION
It has the wrong namespace, this way it can't be called outside the composer package.

Thanks to @rotanev for calling this out