### PR TITLE
Fix non ascii char in phpdoc method name

### DIFF
--- a/lib/Discovery/Crm/Objects/Discovery.php
+++ b/lib/Discovery/Crm/Objects/Discovery.php
@@ -15,7 +15,7 @@ use HubSpot\Discovery\DiscoveryBase;
  * @method AssociationsApi               associationsApi()
  * @method BasicApi                      basicApi()
  * @method BatchApi                      batchApi()
- * @method Calls\Discovery               сalls()
+ * @method Calls\Discovery               calls()
  * @method Communications\Discovery      communications()
  * @method GDPRApi                       gdprApi()
  * @method Emails\Discovery              emails()


### PR DESCRIPTION
Replace a non ascii char to allow IDE autocompletion to work correctly