### PR TITLE
s/Config/Client - correct class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $hubspot = \HubSpot\Factory::createWithAccessToken('your-access-token', $client)
 #### To change the base path
 
 ```php
-$config = new \GuzzleHttp\Config();
+$config = new \GuzzleHttp\Client();
 $config->setBasePath('*');
 $config->setAccessToken('*');
 $config->setDeveloperApiKey('*');


### PR DESCRIPTION
There is no such class as `\GuzzleHttp\Config` the correct class is `\GuzzleHttp\Client`