### PR TITLE
Add new HTTP Error codes handling  in RetryMiddlewareFactory.php

### DIFF
--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -8,24 +8,34 @@ use GuzzleHttp\Psr7\Response;
 
 class RetryMiddlewareFactory
 {
+    private const DEFAULT_MAX_RETRIES = 5;
+    private const INTERNAL_ERROR_RANGES = [
+        [500, 503],
+        [520, 599]
+    ];
+
     public static function createInternalErrorsMiddleware(
         ?callable $delayFunction = null,
-        int $maxRetries = 5
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
     ) {
-        return static::createMiddlewareByHttpCodeRange(500, 504, $delayFunction, $maxRetries);
+        return static::createMiddlewareByHttpCodeRanges(
+            self::INTERNAL_ERROR_RANGES,
+            $delayFunction,
+            $maxRetries
+        );
     }
 
     public static function createRateLimitMiddleware(
         ?callable $delayFunction = null,
-        int $maxRetries = 5
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
     ) {
         return static::createMiddlewareByHttpCodes([429], $delayFunction, $maxRetries);
     }
 
     public static function createMiddlewareByHttpCodes(
         array $codes,
-        callable $delayFunction,
-        int $maxRetries = 5
+        ?callable $delayFunction,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
     ): callable {
         return Middleware::retry(
             static::getRetryFunction($codes, $maxRetries),
@@ -36,31 +46,43 @@ class RetryMiddlewareFactory
     public static function createMiddlewareByHttpCodeRange(
         int $from,
         int $to,
-        callable $delayFunction,
-        int $maxRetries = 5
+        ?callable $delayFunction,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
+    ): callable {
+        return static::createMiddlewareByHttpCodeRanges([[$from, $to]], $delayFunction, $maxRetries);
+    }
+
+    private static function createMiddlewareByHttpCodeRanges(
+        array $ranges,
+        ?callable $delayFunction,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
     ): callable {
         return Middleware::retry(
-            static::getRetryFunctionByRange($from, $to, $maxRetries),
+            static::getRetryFunctionByRanges($ranges, $maxRetries),
             $delayFunction
         );
     }
 
-    public static function getRetryFunctionByRange(
-        int $from,
-        int $to,
-        int $maxRetries = 5
-    ) {
+    private static function getRetryFunctionByRanges(
+        array $ranges,
+        int $maxRetries
+    ): callable {
         return function (
             $retries,
             Request $request,
             ?Response $response = null
-        ) use ($from, $to, $maxRetries) {
+        ) use ($ranges, $maxRetries) {
             if ($retries >= $maxRetries) {
                 return false;
             }
 
-            if ($response instanceof Response) {
-                if (($response->getStatusCode() >= $from) && ($response->getStatusCode() <= $to)) {
+            if (!$response instanceof Response) {
+                return false;
+            }
+
+            $statusCode = $response->getStatusCode();
+            foreach ($ranges as $range) {
+                if ($statusCode >= $range[0] && $statusCode <= $range[1]) {
                     return true;
                 }
             }
@@ -69,8 +91,18 @@ class RetryMiddlewareFactory
         };
     }
 
-    public static function getRetryFunction(array $codes, int $maxRetries = 5)
-    {
+    public static function getRetryFunctionByRange(
+        int $from,
+        int $to,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
+    ): callable {
+        return static::getRetryFunctionByRanges([[$from, $to]], $maxRetries);
+    }
+
+    public static function getRetryFunction(
+        array $codes,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES
+    ): callable {
         return function (
             $retries,
             Request $request,


### PR DESCRIPTION
New RetryMiddleware HTTP Error Codes Handling 
- 504 is removed from the list to allow for a retry in case of server failure.
- range 520-599 is added in order to allow for new codes like the 525 Cloudflare one.
- Range 505-511 still considered as an exception without retry.
- a new function to handle multiple ranges has been added while keeping retro-compatibility
- Default max retries has been refactored into a class constant