### PR TITLE
Update retry middleware factory

### DIFF
--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -8,24 +8,34 @@ use GuzzleHttp\Psr7\Response;
 
 class RetryMiddlewareFactory
 {
+    public const DEFAULT_MAX_RETRIES = 5;
+    public const INTERNAL_ERROR_RANGES = [
+        ['from' => 500, 'to' => 503],
+        ['from' => 520, 'to' => 599]
+    ];
+
     public static function createInternalErrorsMiddleware(
         ?callable $delayFunction = null,
-        int $maxRetries = 5
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
     ) {
-        return static::createMiddlewareByHttpCodeRange(500, 504, $delayFunction, $maxRetries);
+        return static::createMiddlewareByHttpCodeRanges(
+            static::INTERNAL_ERROR_RANGES,
+            $delayFunction,
+            $maxRetries
+        );
     }
 
     public static function createRateLimitMiddleware(
         ?callable $delayFunction = null,
-        int $maxRetries = 5
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
     ) {
         return static::createMiddlewareByHttpCodes([429], $delayFunction, $maxRetries);
     }
 
     public static function createMiddlewareByHttpCodes(
         array $codes,
-        callable $delayFunction,
-        int $maxRetries = 5
+        ?callable $delayFunction,
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
     ): callable {
         return Middleware::retry(
             static::getRetryFunction($codes, $maxRetries),
@@ -36,32 +46,54 @@ class RetryMiddlewareFactory
     public static function createMiddlewareByHttpCodeRange(
         int $from,
         int $to,
-        callable $delayFunction,
-        int $maxRetries = 5
+        ?callable $delayFunction,
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
+    ): callable {
+        return static::createMiddlewareByHttpCodeRanges([[$from, $to]], $delayFunction, $maxRetries);
+    }
+
+    /**
+     * Create middleware by http code ranges
+     * @param array $ranges [['from' => int, 'to' => int]]
+     */
+    public static function createMiddlewareByHttpCodeRanges(
+        array $ranges,
+        ?callable $delayFunction,
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
     ): callable {
         return Middleware::retry(
-            static::getRetryFunctionByRange($from, $to, $maxRetries),
+            static::getRetryFunctionByRanges($ranges, $maxRetries),
             $delayFunction
         );
     }
 
-    public static function getRetryFunctionByRange(
-        int $from,
-        int $to,
-        int $maxRetries = 5
-    ) {
+    /**
+     * Get retry function by code ranges
+     * @param array $ranges [['from' => int, 'to' => int]]
+     */
+    public static function getRetryFunctionByRanges(
+        array $ranges,
+        int $maxRetries
+    ): callable {
         return function (
             $retries,
             Request $request,
             ?Response $response = null
-        ) use ($from, $to, $maxRetries) {
+        ) use ($ranges, $maxRetries) {
             if ($retries >= $maxRetries) {
                 return false;
             }
 
-            if ($response instanceof Response) {
-                if (($response->getStatusCode() >= $from) && ($response->getStatusCode() <= $to)) {
-                    return true;
+            if (!$response instanceof Response) {
+                return false;
+            }
+
+            $statusCode = $response->getStatusCode();
+            foreach ($ranges as $range) {
+                if (key_exists('from', $range) && key_exists('to', $range)) {
+                    if ($statusCode >= $range['from'] && $statusCode <= $range['to']) {
+                        return true;
+                    }
                 }
             }
 
@@ -69,8 +101,18 @@ class RetryMiddlewareFactory
         };
     }
 
-    public static function getRetryFunction(array $codes, int $maxRetries = 5)
-    {
+    public static function getRetryFunctionByRange(
+        int $from,
+        int $to,
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
+    ): callable {
+        return static::getRetryFunctionByRanges([['from' => $from, 'to' => $to]], $maxRetries);
+    }
+
+    public static function getRetryFunction(
+        array $codes,
+        int $maxRetries = static::DEFAULT_MAX_RETRIES
+    ): callable {
         return function (
             $retries,
             Request $request,


### PR DESCRIPTION
### New RetryMiddleware HTTP Error Codes Handling

- 504 is removed from the list to allow for a retry in case of server failure.
- range 520-599 is added in order to allow for new codes like the 525 Cloudflare one.
- Range 505-511 still considered as an exception without retry.
- a new function to handle multiple ranges has been added while keeping retro-compatibility
- Default max retries has been refactored into a class constant