### PR TITLE
Adjust subclass when deserializing field types

### DIFF
--- a/codegen/Marketing/Forms/ObjectSerializer.php
+++ b/codegen/Marketing/Forms/ObjectSerializer.php
@@ -421,9 +421,14 @@ class ObjectSerializer
                 throw new \InvalidArgumentException("Invalid array '$class'");
             }
 
-            $subClass = substr($class, 0, -2);
+            $originalSubclass = $subClass = substr($class, 0, -2);
             $values = [];
             foreach ($data as $key => $value) {
+                if ($originalSubclass === '\HubSpot\Client\Marketing\Forms\Model\DependentFieldDependentField' && isset($value->fieldType)) {
+                    $parts = explode('_', $value->fieldType);
+                    $parts = array_map('ucfirst', $parts);
+                    $subClass = '\HubSpot\Client\Marketing\Forms\Model\\' . implode('', $parts) . 'Field';
+                }
                 $values[] = self::deserialize($value, $subClass, null);
             }
             return $values;


### PR DESCRIPTION
# Fixes #294 

During deserialization when a FieldGroup type is deserialized the `$openAPITypes` always defines `fields` as a type of `\HubSpot\Client\Marketing\Forms\Model\DependentFieldDependentField[]` (see \HubSpot\Client\Marketing\Forms\Model\FieldGroup:64)

This PR dynamically adjust the subclass for the field types so they are deserialized using their appropriate model