### PR TITLE
Add retry middleware support for transient cURL connection errors (52/55/56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ $handlerStack->push(
     )
 );
 
+$handlerStack->push(
+    \HubSpot\RetryMiddlewareFactory::createConnectionErrorsMiddleware(
+        \HubSpot\Delay::getExponentialDelayFunction(2)
+    )
+);
+
 $client = new \GuzzleHttp\Client(['handler' => $handlerStack]);
 
 $hubspot = \HubSpot\Factory::createWithAccessToken('your-access-token', $client);

--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -2,7 +2,7 @@
 
 namespace HubSpot;
 
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -153,13 +153,13 @@ class RetryMiddlewareFactory
             $retries,
             Request $request,
             ?Response $response = null,
-            ?RequestException $exception = null
+            $exception = null
         ) use ($maxRetries, $curlErrorCodes) {
             if ($retries >= $maxRetries) {
                 return false;
             }
 
-            if (!$exception instanceof RequestException) {
+            if (!$exception instanceof ConnectException) {
                 return false;
             }
 

--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -2,6 +2,7 @@
 
 namespace HubSpot;
 
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -9,10 +10,22 @@ use GuzzleHttp\Psr7\Response;
 class RetryMiddlewareFactory
 {
     public const DEFAULT_MAX_RETRIES = 5;
+    public const TRANSIENT_CURL_ERROR_CODES = [52, 55, 56];
     public const INTERNAL_ERROR_RANGES = [
         ['from' => 500, 'to' => 503],
         ['from' => 520, 'to' => 599],
     ];
+
+    public static function createConnectionErrorsMiddleware(
+        ?callable $delayFunction = null,
+        int $maxRetries = self::DEFAULT_MAX_RETRIES,
+        array $curlErrorCodes = self::TRANSIENT_CURL_ERROR_CODES
+    ): callable {
+        return Middleware::retry(
+            static::getRetryFunctionByConnectionErrors($maxRetries, $curlErrorCodes),
+            $delayFunction
+        );
+    }
 
     public static function createInternalErrorsMiddleware(
         ?callable $delayFunction = null,
@@ -126,6 +139,39 @@ class RetryMiddlewareFactory
 
             if (($response instanceof Response) && in_array($response->getStatusCode(), $codes)) {
                 return true;
+            }
+
+            return false;
+        };
+    }
+
+    public static function getRetryFunctionByConnectionErrors(
+        int $maxRetries = self::DEFAULT_MAX_RETRIES,
+        array $curlErrorCodes = self::TRANSIENT_CURL_ERROR_CODES
+    ): callable {
+        return function (
+            $retries,
+            Request $request,
+            ?Response $response = null,
+            ?RequestException $exception = null
+        ) use ($maxRetries, $curlErrorCodes) {
+            if ($retries >= $maxRetries) {
+                return false;
+            }
+
+            if (!$exception instanceof RequestException) {
+                return false;
+            }
+
+            $handlerContext = $exception->getHandlerContext();
+            $errno = $handlerContext['errno'] ?? null;
+
+            if (is_numeric($errno) && in_array((int) $errno, $curlErrorCodes, true)) {
+                return true;
+            }
+
+            if (preg_match('/cURL error\s+(\d+):/i', $exception->getMessage(), $matches) === 1) {
+                return in_array((int) $matches[1], $curlErrorCodes, true);
             }
 
             return false;

--- a/tests/Unit/RetryMiddlewareFactoryTest.php
+++ b/tests/Unit/RetryMiddlewareFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Hubspot\Tests\Unit;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use HubSpot\RetryMiddlewareFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class RetryMiddlewareFactoryTest extends TestCase
+{
+    /** @test */
+    public function itRetriesRetriableConnectionErrorsByErrno(): void
+    {
+        $retry = RetryMiddlewareFactory::getRetryFunctionByConnectionErrors(3);
+        $request = new Request('GET', 'https://api.hubapi.com/test');
+        $exception = new ConnectException(
+            'cURL error 56: OpenSSL SSL_read unexpected eof while reading',
+            $request,
+            null,
+            ['errno' => 56]
+        );
+
+        $this->assertTrue($retry(0, $request, null, $exception));
+    }
+
+    /** @test */
+    public function itRetriesRetriableConnectionErrorsByMessageWhenErrnoMissing(): void
+    {
+        $retry = RetryMiddlewareFactory::getRetryFunctionByConnectionErrors(3);
+        $request = new Request('GET', 'https://api.hubapi.com/test');
+        $exception = new ConnectException(
+            'cURL error 55: Send failure: Broken pipe',
+            $request
+        );
+
+        $this->assertTrue($retry(0, $request, null, $exception));
+    }
+
+    /** @test */
+    public function itDoesNotRetryNonRetriableConnectionErrors(): void
+    {
+        $retry = RetryMiddlewareFactory::getRetryFunctionByConnectionErrors(3);
+        $request = new Request('GET', 'https://api.hubapi.com/test');
+        $exception = new ConnectException(
+            'cURL error 60: SSL certificate problem',
+            $request,
+            null,
+            ['errno' => 60]
+        );
+
+        $this->assertFalse($retry(0, $request, null, $exception));
+    }
+
+    /** @test */
+    public function itStopsRetryingWhenMaxRetriesReached(): void
+    {
+        $retry = RetryMiddlewareFactory::getRetryFunctionByConnectionErrors(1);
+        $request = new Request('GET', 'https://api.hubapi.com/test');
+        $exception = new ConnectException(
+            'cURL error 56: OpenSSL SSL_read unexpected eof while reading',
+            $request,
+            null,
+            ['errno' => 56]
+        );
+
+        $this->assertFalse($retry(1, $request, null, $exception));
+    }
+}


### PR DESCRIPTION
Fixes #597.

Adds opt-in retry support for transient transport-level cURL failures that currently bypass HTTP-status retry middleware.

### Changes
- Add `createConnectionErrorsMiddleware(...)`
- Add `getRetryFunctionByConnectionErrors(...)`
- Default retriable cURL error codes: `52`, `55`, `56`
- Add unit tests for:
  - retriable errno/message cases
  - non-retriable case
  - max-retry cutoff
- Update README retry example to include connection-error middleware