### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests/ export-ignore
+/.github/ export-ignore
+/.php-cs-fixer.php export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was none. The files below have been added or modified since, and are still included in the composer dist:
- `/tests/ export-ignore` — last touched in 6319326 2026-05-11
- `/.github/ export-ignore` — last touched in 32e8839 2026-02-20
- `/.php-cs-fixer.php export-ignore` — last touched in 5750de5 2022-02-15
- `/.gitattributes export-ignore` — last touched in new
- `/.gitignore export-ignore` — last touched in new

Background reading: https://blog.madewithlove.be/post/gitattributes/